### PR TITLE
Added conversion from FGMCEMovementSampleCollection to FPoseSearchQue…

### DIFF
--- a/GMCExtended.uplugin
+++ b/GMCExtended.uplugin
@@ -25,6 +25,10 @@
 		{
 			"Name": "GMC",
 			"Enabled": true
+		},
+		{
+			"Name": "PoseSearch",
+			"Enabled": true
 		}
 	]
 }

--- a/Source/GMCExtended/GMCExtended.Build.cs
+++ b/Source/GMCExtended/GMCExtended.Build.cs
@@ -27,7 +27,7 @@ public class GMCExtended : ModuleRules
 			{
 				"Core",
 				"GMCCore",
-				"GameplayTags",
+				"GameplayTags", "PoseSearch"
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);

--- a/Source/GMCExtended/Private/Support/GMCE_UtilityLibrary.cpp
+++ b/Source/GMCExtended/Private/Support/GMCE_UtilityLibrary.cpp
@@ -55,3 +55,17 @@ FTrajectorySampleRange UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToTr
 	// Just use the FGMCE_MovementSampleRange's own conversion operator.
 	return static_cast<FTrajectorySampleRange>(MovementSampleCollection);
 }
+
+FPoseSearchQueryTrajectorySample UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToPoseSearchQueryTrajectorySample(
+	const FGMCE_MovementSample& MovementSample)
+{
+	// Just use the FPoseSearchQueryTrajectorySample's own conversion operator.
+	return static_cast<FPoseSearchQueryTrajectorySample>(MovementSample);
+}
+
+FPoseSearchQueryTrajectory UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToPoseSearchQueryTrajectory(
+	const FGMCE_MovementSampleCollection& MovementSampleCollection)
+{
+	// Just use the FPoseSearchQueryTrajectory's own conversion operator.
+	return static_cast<FPoseSearchQueryTrajectory>(MovementSampleCollection);
+}

--- a/Source/GMCExtended/Public/Support/GMCEMovementSample.h
+++ b/Source/GMCExtended/Public/Support/GMCEMovementSample.h
@@ -14,6 +14,7 @@
 
 #include "CoreMinimal.h"
 #include "Animation/MotionTrajectoryTypes.h"
+#include "PoseSearch/PoseSearchTrajectoryTypes.h"
 #include "GMCEMovementSample.generated.h"
 
 USTRUCT(BlueprintType)
@@ -159,7 +160,18 @@ struct GMCEXTENDED_API FGMCE_MovementSample
 
 		return Result;
 	}
-	
+
+	// ReSharper disable once CppNonExplicitConversionOperator
+	operator FPoseSearchQueryTrajectorySample() const
+	{
+		FPoseSearchQueryTrajectorySample Result; 
+
+		Result.AccumulatedSeconds = AccumulatedSeconds;
+		Result.Position = RelativeTransform.GetTranslation();  
+		Result.Facing = RelativeTransform.GetRotation();
+
+		return Result;
+	}
 };
 
 USTRUCT(BlueprintType)
@@ -183,6 +195,20 @@ struct GMCEXTENDED_API FGMCE_MovementSampleCollection
 		{
 			// Implicit conversion gives us an FTrajectorySample
 			Result.Samples.Emplace(static_cast<FTrajectorySample>(Sample));
+		}
+
+		return Result;
+	}
+
+	// ReSharper disable once CppNonExplicitConversionOperator
+	operator FPoseSearchQueryTrajectory() const
+	{
+		FPoseSearchQueryTrajectory Result;
+		Result.Samples.Reserve(Samples.Num());
+
+		for (const FGMCE_MovementSample& Sample : Samples)
+		{
+			Result.Samples.Emplace(static_cast<FPoseSearchQueryTrajectorySample>(Sample));
 		}
 
 		return Result;

--- a/Source/GMCExtended/Public/Support/GMCE_UtilityLibrary.h
+++ b/Source/GMCExtended/Public/Support/GMCE_UtilityLibrary.h
@@ -39,4 +39,12 @@ public:
 	/// Converts a GMCEx Movement Sample Collection into an Epic Trajectory Sample Range.
 	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
 	static FTrajectorySampleRange ConvertMovementSampleCollectionToTrajectorySampleRange(const FGMCE_MovementSampleCollection& MovementSampleCollection);
+
+	/// Converts a GMCEx Movement Sample into an Epic Pose Search Query Trajectory Sample.
+	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
+	static FPoseSearchQueryTrajectorySample ConvertMovementSampleCollectionToPoseSearchQueryTrajectorySample(const FGMCE_MovementSample& MovementSample);
+	
+	/// Converts a GMCEx Movement Sample Collection into an Epic Pose Search Query Trajectory.
+	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
+	static FPoseSearchQueryTrajectory ConvertMovementSampleCollectionToPoseSearchQueryTrajectory(const FGMCE_MovementSampleCollection& MovementSampleCollection);
 };


### PR DESCRIPTION
The FTrajectorySampleRange is flagged in UE 5.4 as soon-to-be-deprecated and should be replaced with FPoseSearchQueryTrajectory. My update provides that change while keeping the original FTrajectorySampleRange for users not ready to update. 