### PR TITLE
UE 5.6 Compatibility Changes

### DIFF
--- a/GMCExtended.uplugin
+++ b/GMCExtended.uplugin
@@ -18,7 +18,7 @@
 		{
 			"Name": "GMCExtended",
 			"Type": "Runtime",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "PreDefault"
 		},
 		{
 			"Name": "GMCExtendedAnimation",

--- a/Source/GMCExtended/Private/Components/GMCE_OrganicMovementCmp.cpp
+++ b/Source/GMCExtended/Private/Components/GMCE_OrganicMovementCmp.cpp
@@ -771,7 +771,7 @@ void UGMCE_OrganicMovementCmp::PhysicsCustom_Implementation(float DeltaSeconds)
 				FVector NewLocation = CurrentRagdollGoal;
 				NewLocation.Z = UpdatedComponent->GetComponentLocation().Z;
 				FCollisionQueryParams CollisionParameters = FCollisionQueryParams(NAME_None, true, GetOwner());
-				CollisionParameters.AddIgnoredComponent(UpdatedPrimitive);
+				//CollisionParameters.AddIgnoredComponent(UpdatedPrimitive);
 				
 				FHitResult GroundHit;
 				const FVector StartCheck = CurrentRagdollGoal + FVector(0.f, 0.f, PreviousCollisionHalfHeight);

--- a/Source/GMCExtended/Private/Support/GMCE_UtilityLibrary.cpp
+++ b/Source/GMCExtended/Private/Support/GMCE_UtilityLibrary.cpp
@@ -39,34 +39,18 @@ float UGMCE_UtilityLibrary::GetAngleDifference(const FVector& A, const FVector& 
 	return (180.0)/UE_DOUBLE_PI * FMath::Acos(DotProduct);	
 }
 
-// 
-FTrajectorySample UGMCE_UtilityLibrary::ConvertMovementSampleToTrajectorySample(const FGMCE_MovementSample& Sample)
-{
-	// Just use the FGMCE_MovementSample's own conversion operator.
-	return static_cast<FTrajectorySample>(Sample);
-}
-
-PRAGMA_DISABLE_DEPRECATION_WARNINGS
-FTrajectorySampleRange UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToTrajectorySampleRange(
-	const FGMCE_MovementSampleCollection& MovementSampleCollection)
-{
-	// Just use the FGMCE_MovementSampleRange's own conversion operator.
-	return static_cast<FTrajectorySampleRange>(MovementSampleCollection);
-}
-PRAGMA_ENABLE_DEPRECATION_WARNINGS
-
-FPoseSearchQueryTrajectorySample UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToPoseSearchQueryTrajectorySample(
+FTransformTrajectorySample UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToTransformTrajectorySample(
 	const FGMCE_MovementSample& MovementSample)
 {
 	// Just use the FPoseSearchQueryTrajectorySample's own conversion operator.
-	return static_cast<FPoseSearchQueryTrajectorySample>(MovementSample);
+	return static_cast<FTransformTrajectorySample>(MovementSample);
 }
 
-FPoseSearchQueryTrajectory UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToPoseSearchQueryTrajectory(
+FTransformTrajectory UGMCE_UtilityLibrary::ConvertMovementSampleCollectionToTransformTrajectory(
 	const FGMCE_MovementSampleCollection& MovementSampleCollection)
 {
 	// Just use the FPoseSearchQueryTrajectory's own conversion operator.
-	return static_cast<FPoseSearchQueryTrajectory>(MovementSampleCollection);
+	return static_cast<FTransformTrajectory>(MovementSampleCollection);
 }
 
 float UGMCE_UtilityLibrary::GetSynchronizedWorldTime(UObject* WorldContextObject)

--- a/Source/GMCExtended/Public/Support/GMCE_UtilityLibrary.h
+++ b/Source/GMCExtended/Public/Support/GMCE_UtilityLibrary.h
@@ -29,25 +29,15 @@ public:
 	/// defined by their cross product.
 	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
 	static float GetAngleDifference(const FVector& A, const FVector& B);
-
-	/// Converts a GMCEx Movement Sample into an Epic Trajectory Sample.
-	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
-	static FTrajectorySample ConvertMovementSampleToTrajectorySample(const FGMCE_MovementSample& MovementSample);
-
-	PRAGMA_DISABLE_DEPRECATION_WARNINGS	
-	/// Converts a GMCEx Movement Sample Collection into an Epic Trajectory Sample Range.
-	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
-	static FTrajectorySampleRange ConvertMovementSampleCollectionToTrajectorySampleRange(const FGMCE_MovementSampleCollection& MovementSampleCollection);
-	PRAGMA_ENABLE_DEPRECATION_WARNINGS
-
-	/// Converts a GMCEx Movement Sample into an Epic Pose Search Query Trajectory Sample.
-	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
-	static FPoseSearchQueryTrajectorySample ConvertMovementSampleCollectionToPoseSearchQueryTrajectorySample(const FGMCE_MovementSample& MovementSample);
 	
-	/// Converts a GMCEx Movement Sample Collection into an Epic Pose Search Query Trajectory.
+	/// Converts a GMCEx Movement Sample into an Epic Transform Trajectory Sample.
 	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
-	static FPoseSearchQueryTrajectory ConvertMovementSampleCollectionToPoseSearchQueryTrajectory(const FGMCE_MovementSampleCollection& MovementSampleCollection);
-
+	static FTransformTrajectorySample ConvertMovementSampleCollectionToTransformTrajectorySample(const FGMCE_MovementSample& MovementSample);
+	
+	/// Converts a GMCEx Movement Sample Collection into an Epic Transform Trajectory.
+	UFUNCTION(BlueprintPure, Category="Movement Trajectory")
+	static FTransformTrajectory ConvertMovementSampleCollectionToTransformTrajectory(const FGMCE_MovementSampleCollection& MovementSampleCollection);
+	
 	/// Get the server's RealTimeSeconds, as synchronized by GMC.
 	UFUNCTION(BlueprintPure, Category="Time")
 	static float GetSynchronizedWorldTime(UObject *WorldContextObject);


### PR DESCRIPTION
Updates to Compile on 5.6

Will break the plugin for UE5.4 and lower due to changed Motion Matching structs that were removed from the newer engine version.